### PR TITLE
Do not accept pages with URL /404 into sitemap

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -16,7 +16,7 @@
     {% endfor %}
   {% endfor %}
 
-  {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html" and doc.url != "/404"' %}
+  {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html"' | where_exp:'doc','doc.url != "/404"' %}
   {% for page in pages %}
     <url>
       <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>

--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -16,7 +16,7 @@
     {% endfor %}
   {% endfor %}
 
-  {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html"' %}
+  {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html" and doc.url != "/404"' %}
   {% for page in pages %}
     <url>
       <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>

--- a/spec/fixtures/404v2.md
+++ b/spec/fixtures/404v2.md
@@ -1,0 +1,5 @@
+---
+permalink: /404
+---
+
+404. That's an error.

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -131,6 +131,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match %r!/404\.html</loc>!
   end
 
+  it "does not include the 404 page" do
+    expect(contents).not_to match %r!/404</loc>!
+  end
+
   it "does not format timestamps of static files" do
     expect(contents).not_to match %r!/test\.pdf</loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}</lastmod>!
   end


### PR DESCRIPTION
Reject any files where the URL is `/404` to be put into the sitemap, not just `/404.html`.