### PR TITLE
Do not include paginated pages in sitemap

### DIFF
--- a/lib/sitemap.xml
+++ b/lib/sitemap.xml
@@ -18,12 +18,14 @@
 
   {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html"' | where_exp:'doc','doc.url != "/404"' %}
   {% for page in pages %}
-    <url>
-      <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
-      {% if page.last_modified_at %}
-        <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
-      {% endif %}
-    </url>
+    {% unless page.pagination_info["curr_page"] > 1 %}
+      <url>
+        <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+        {% if page.last_modified_at %}
+          <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+        {% endif %}
+      </url>
+    {% endunless %}
   {% endfor %}
 
   {% assign static_files = page.static_files | where_exp:'page','page.sitemap != false' | where_exp:'page','page.name != "404.html"' %}

--- a/spec/fixtures/paginated_page.md
+++ b/spec/fixtures/paginated_page.md
@@ -1,0 +1,7 @@
+---
+permalink: /permalink/paginated/2/index.html
+pagination_info:
+  curr_page: 2
+---
+
+# Unique html name

--- a/spec/jekyll-sitemap_spec.rb
+++ b/spec/jekyll-sitemap_spec.rb
@@ -135,6 +135,10 @@ describe(Jekyll::JekyllSitemap) do
     expect(contents).not_to match %r!/404</loc>!
   end
 
+  it "does not include pages that are paginated" do
+    expect(contents).not_to match %r!/permalink/2/</loc>!
+  end
+
   it "does not format timestamps of static files" do
     expect(contents).not_to match %r!/test\.pdf</loc>\s+<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(-|\+)\d{2}:\d{2}</lastmod>!
   end


### PR DESCRIPTION
Do not include the paginated pages in the sitemap if the current page of the pagination is `> 1`. Each paginated page has `paginated_info` attributes on the page that we can use to determine the placement of the current page in the pagination list.